### PR TITLE
Refatorar autenticação: substituir cookies por JWT via header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@ obj/
 /packages/
 riderModule.iml
 /_ReSharper.Caches/
+.idea/.idea.library-management-api/.idea/.gitignore
+.idea/.idea.library-management-api/.idea/dataSources.xml
+.idea/.idea.library-management-api/.idea/encodings.xml
+.idea/.idea.library-management-api/.idea/indexLayout.xml
+.idea/.idea.library-management-api/.idea/vcs.xml

--- a/library-management-api/Controllers/AuthController.cs
+++ b/library-management-api/Controllers/AuthController.cs
@@ -20,48 +20,13 @@ namespace library_management_api.Controllers
         public async Task<ActionResult<ResponseModel<AuthResponseDto>>> Signup(SignupRequestDto signupRequest)
         {
             var response = await _authInterface.Signup(signupRequest);
-            var token = _authInterface.GetAccessToken(response.Data.Id, response.Data.Name);
-
-            var cookieOptions = new CookieOptions
-            {
-                HttpOnly = true,
-                Secure = true,
-                SameSite = SameSiteMode.Strict,
-                Expires = DateTime.UtcNow.AddDays(7)
-            };
-
-            Response.Cookies.Append("AuthCookie", token, cookieOptions);
             return Ok(response);
         }
         [HttpPost("signin")]
         public async Task<ActionResult<ResponseModel<AuthResponseDto>>> Signup(SigninRequestDto signinRequest)
         {
             var response = await _authInterface.Signin(signinRequest);
-            var token = _authInterface.GetAccessToken(response.Data.Id, response.Data.Name);
-
-            var cookieOptions = new CookieOptions
-            {
-                HttpOnly = true,
-                Secure = true,
-                SameSite = SameSiteMode.Strict,
-                Expires = DateTime.UtcNow.AddDays(7)
-            };
-
-            Response.Cookies.Append("AuthCookie", token, cookieOptions);
             return Ok(response);
-        }
-        [HttpPost("logout")]
-        public IActionResult Logout()
-        {
-            var cookieOptions = new CookieOptions
-            {
-                HttpOnly = true,
-                Secure = true,
-                SameSite = SameSiteMode.Strict,
-                Expires = DateTime.UtcNow.AddDays(-1)
-            };
-            Response.Cookies.Delete("AuthCookie", cookieOptions);
-            return Ok(new { Message = "Logout realizado com sucesso" });
         }
     }
 }

--- a/library-management-api/Controllers/AuthorController.cs
+++ b/library-management-api/Controllers/AuthorController.cs
@@ -26,7 +26,8 @@ namespace library_management_api.Controllers
         [HttpPost]
         public async Task<ActionResult<ResponseModel<AuthorModel>>> AddAuthor(AddAuthorRequestDto request)
         {
-            var token = HttpContext.Request.Cookies["AuthCookie"];
+            var authorizationHeader = Request.Headers["Authorization"].ToString();
+            var token = authorizationHeader.Substring("Bearer ".Length).Trim();
             var library = await _authInterface.VerifyAccessToken(token);
             if (library is null)
             {
@@ -38,7 +39,8 @@ namespace library_management_api.Controllers
         [HttpGet]
         public async Task<ActionResult<ResponseModel<object>>> GetAllAuthors()
         {
-            var token = HttpContext.Request.Cookies["AuthCookie"];
+            var authorizationHeader = Request.Headers["Authorization"].ToString();
+            var token = authorizationHeader.Substring("Bearer ".Length).Trim();
             var library = await _authInterface.VerifyAccessToken(token);
             if (library is null)
             {
@@ -50,7 +52,8 @@ namespace library_management_api.Controllers
         [HttpGet("{Id}")]
         public async Task<ActionResult<ResponseModel<AuthorModel>>> GetAuthor(Guid Id)
         {
-            var token = HttpContext.Request.Cookies["AuthCookie"];
+            var authorizationHeader = Request.Headers["Authorization"].ToString();
+            var token = authorizationHeader.Substring("Bearer ".Length).Trim();
             var library = await _authInterface.VerifyAccessToken(token);
             if (library is null)
             {
@@ -62,7 +65,8 @@ namespace library_management_api.Controllers
         [HttpGet("byname/{Name}")]
         public async Task<ActionResult<ResponseModel<AuthorModel>>> GetAuthorByName(string Name)
         {
-            var token = HttpContext.Request.Cookies["AuthCookie"];
+            var authorizationHeader = Request.Headers["Authorization"].ToString();
+            var token = authorizationHeader.Substring("Bearer ".Length).Trim();
             var library = await _authInterface.VerifyAccessToken(token);
             if (library is null)
             {
@@ -74,7 +78,8 @@ namespace library_management_api.Controllers
         [HttpPut("{Id}")]
         public async Task<ActionResult<ResponseModel<AuthorModel>>> EditAuthor(Guid Id, EditAuthorRequestDto request)
         {
-            var token = HttpContext.Request.Cookies["AuthCookie"];
+            var authorizationHeader = Request.Headers["Authorization"].ToString();
+            var token = authorizationHeader.Substring("Bearer ".Length).Trim();
             var library = await _authInterface.VerifyAccessToken(token);
             if (library is null)
             {
@@ -86,7 +91,8 @@ namespace library_management_api.Controllers
         [HttpDelete("{Id}")]
         public async Task<ActionResult<ResponseModel<AuthorModel>>> DeleteAuthor(Guid Id)
         {
-            var token = HttpContext.Request.Cookies["AuthCookie"];
+            var authorizationHeader = Request.Headers["Authorization"].ToString();
+            var token = authorizationHeader.Substring("Bearer ".Length).Trim();
             var library = await _authInterface.VerifyAccessToken(token);
             if (library is null)
             {

--- a/library-management-api/Controllers/BookController.cs
+++ b/library-management-api/Controllers/BookController.cs
@@ -26,7 +26,8 @@ namespace library_management_api.Controllers
         [HttpPost]
         public async Task<ActionResult<ResponseModel<BookModel>>> AddBook(AddBookRequestDto request)
         {
-            var token = HttpContext.Request.Cookies["AuthCookie"];
+            var authorizationHeader = Request.Headers["Authorization"].ToString();
+            var token = authorizationHeader.Substring("Bearer ".Length).Trim();
             var library = await _authInterface.VerifyAccessToken(token);
             if (library is null)
             {
@@ -38,7 +39,8 @@ namespace library_management_api.Controllers
         [HttpGet]
         public async Task<ActionResult<ResponseModel<List<BookModel>>>> GetAllBooks()
         {
-            var token = HttpContext.Request.Cookies["AuthCookie"];
+            var authorizationHeader = Request.Headers["Authorization"].ToString();
+            var token = authorizationHeader.Substring("Bearer ".Length).Trim();
             var library = await _authInterface.VerifyAccessToken(token);
             if (library is null)
             {
@@ -50,7 +52,8 @@ namespace library_management_api.Controllers
         [HttpGet("{Id}")]
         public async Task<ActionResult<ResponseModel<BookModel>>> GetBook(Guid Id)
         {
-            var token = HttpContext.Request.Cookies["AuthCookie"];
+            var authorizationHeader = Request.Headers["Authorization"].ToString();
+            var token = authorizationHeader.Substring("Bearer ".Length).Trim();
             var library = await _authInterface.VerifyAccessToken(token);
             if (library is null)
             {
@@ -62,7 +65,8 @@ namespace library_management_api.Controllers
         [HttpGet("bytitle/{Title}")]
         public async Task<ActionResult<ResponseModel<BookModel>>> GetBookByTitle(string Title)
         {
-            var token = HttpContext.Request.Cookies["AuthCookie"];
+            var authorizationHeader = Request.Headers["Authorization"].ToString();
+            var token = authorizationHeader.Substring("Bearer ".Length).Trim();
             var library = await _authInterface.VerifyAccessToken(token);
             if (library is null)
             {
@@ -74,7 +78,8 @@ namespace library_management_api.Controllers
         [HttpPut]
         public async Task<ActionResult<ResponseModel<BookModel>>> EditBook(EditBookRequestDto request)
         {
-            var token = HttpContext.Request.Cookies["AuthCookie"];
+            var authorizationHeader = Request.Headers["Authorization"].ToString();
+            var token = authorizationHeader.Substring("Bearer ".Length).Trim();
             var library = await _authInterface.VerifyAccessToken(token);
             if (library is null)
             {
@@ -86,7 +91,8 @@ namespace library_management_api.Controllers
         [HttpDelete("{Id}")]
         public async Task<ActionResult<ResponseModel<BookModel>>> DeleteBook(Guid Id)
         {
-            var token = HttpContext.Request.Cookies["AuthCookie"];
+            var authorizationHeader = Request.Headers["Authorization"].ToString();
+            var token = authorizationHeader.Substring("Bearer ".Length).Trim();
             var library = await _authInterface.VerifyAccessToken(token);
             if (library is null)
             {

--- a/library-management-api/Controllers/LibraryController.cs
+++ b/library-management-api/Controllers/LibraryController.cs
@@ -26,7 +26,8 @@ namespace library_management_api.Controllers
         [HttpGet]
         public async Task<ActionResult<ResponseModel<LibraryResponseDto>>> GetLibrary()
         {
-            var token = HttpContext.Request.Cookies["AuthCookie"];
+            var authorizationHeader = Request.Headers["Authorization"].ToString();
+            var token = authorizationHeader.Substring("Bearer ".Length).Trim();
             var library = await _authInterface.VerifyAccessToken(token);
             if (library is null)
             {
@@ -39,7 +40,8 @@ namespace library_management_api.Controllers
         [HttpPut]
         public async Task<ActionResult<ResponseModel<LibraryResponseDto>>> EditLibrary(EditLibraryRequestDto request)
         {
-            var token = HttpContext.Request.Cookies["AuthCookie"];
+            var authorizationHeader = Request.Headers["Authorization"].ToString();
+            var token = authorizationHeader.Substring("Bearer ".Length).Trim();
             var library = await _authInterface.VerifyAccessToken(token);
             if (library is null)
             {
@@ -52,7 +54,8 @@ namespace library_management_api.Controllers
         [HttpDelete]
         public async Task<ActionResult<ResponseModel<LibraryResponseDto>>> DeleteLibrary(string password)
         {
-            var token = HttpContext.Request.Cookies["AuthCookie"];
+            var authorizationHeader = Request.Headers["Authorization"].ToString();
+            var token = authorizationHeader.Substring("Bearer ".Length).Trim();
             var library = await _authInterface.VerifyAccessToken(token);
             if (library is null)
             {

--- a/library-management-api/Controllers/LoanController.cs
+++ b/library-management-api/Controllers/LoanController.cs
@@ -26,7 +26,8 @@ namespace library_management_api.Controllers
         [HttpPost]
         public async Task<ActionResult<ResponseModel<LoanModel>>> RegisterNewLoan(RegisterNewLoanRequestDto request)
         {
-            var token = HttpContext.Request.Cookies["AuthCookie"];
+            var authorizationHeader = Request.Headers["Authorization"].ToString();
+            var token = authorizationHeader.Substring("Bearer ".Length).Trim();
             var library = await _authInterface.VerifyAccessToken(token);
             if (library is null)
             {
@@ -38,7 +39,8 @@ namespace library_management_api.Controllers
         [HttpGet]
         public async Task<ActionResult<ResponseModel<List<LoanResponseDto>>>> GetAllLoans()
         {
-            var token = HttpContext.Request.Cookies["AuthCookie"];
+            var authorizationHeader = Request.Headers["Authorization"].ToString();
+            var token = authorizationHeader.Substring("Bearer ".Length).Trim();
             var library = await _authInterface.VerifyAccessToken(token);
             if (library is null)
             {
@@ -50,7 +52,8 @@ namespace library_management_api.Controllers
         [HttpGet("{id}")]
         public async Task<ActionResult<ResponseModel<LoanResponseDto>>> GetLoan(Guid id)
         {
-            var token = HttpContext.Request.Cookies["AuthCookie"];
+            var authorizationHeader = Request.Headers["Authorization"].ToString();
+            var token = authorizationHeader.Substring("Bearer ".Length).Trim();
             var library = await _authInterface.VerifyAccessToken(token);
             if (library is null)
             {
@@ -62,7 +65,8 @@ namespace library_management_api.Controllers
         [HttpPut("return/{id}")]
         public async Task<ActionResult<ResponseModel<LoanResponseDto>>> ReturnBook(Guid id)
         {
-            var token = HttpContext.Request.Cookies["AuthCookie"];
+            var authorizationHeader = Request.Headers["Authorization"].ToString();
+            var token = authorizationHeader.Substring("Bearer ".Length).Trim();
             var library = await _authInterface.VerifyAccessToken(token);
             if (library is null)
             {

--- a/library-management-api/Controllers/ReaderController.cs
+++ b/library-management-api/Controllers/ReaderController.cs
@@ -26,7 +26,8 @@ namespace library_management_api.Controllers
         [HttpPost]
         public async Task<ActionResult<ResponseModel<ReaderModel>>> AddReader(AddReaderRequestDto request)
         {
-            var token = HttpContext.Request.Cookies["AuthCookie"];
+            var authorizationHeader = Request.Headers["Authorization"].ToString();
+            var token = authorizationHeader.Substring("Bearer ".Length).Trim();
             var library = await _authInterface.VerifyAccessToken(token);
             if (library is null)
             {
@@ -38,7 +39,8 @@ namespace library_management_api.Controllers
         [HttpGet]
         public async Task<ActionResult<ResponseModel<Object>>> GetAllReaders()
         {
-            var token = HttpContext.Request.Cookies["AuthCookie"];
+            var authorizationHeader = Request.Headers["Authorization"].ToString();
+            var token = authorizationHeader.Substring("Bearer ".Length).Trim();
             var library = await _authInterface.VerifyAccessToken(token);
             if (library is null)
             {
@@ -50,7 +52,8 @@ namespace library_management_api.Controllers
         [HttpGet("{Id}")]
         public async Task<ActionResult<ResponseModel<Object>>> GetReaderById(Guid Id)
         {
-            var token = HttpContext.Request.Cookies["AuthCookie"];
+            var authorizationHeader = Request.Headers["Authorization"].ToString();
+            var token = authorizationHeader.Substring("Bearer ".Length).Trim();
             var library = await _authInterface.VerifyAccessToken(token);
             if (library is null)
             {
@@ -62,7 +65,8 @@ namespace library_management_api.Controllers
         [HttpGet("byname/{Name}")]
         public async Task<ActionResult<ResponseModel<List<ReaderModel>>>> GetReaderByName(string Name)
         {
-            var token = HttpContext.Request.Cookies["AuthCookie"];
+            var authorizationHeader = Request.Headers["Authorization"].ToString();
+            var token = authorizationHeader.Substring("Bearer ".Length).Trim();
             var library = await _authInterface.VerifyAccessToken(token);
             if (library is null)
             {
@@ -74,7 +78,8 @@ namespace library_management_api.Controllers
         [HttpPut("{Id}")]
         public async Task<ActionResult<ResponseModel<ReaderModel>>> EditReader(Guid Id, EditReaderRequestDto request)
         {
-            var token = HttpContext.Request.Cookies["AuthCookie"];
+            var authorizationHeader = Request.Headers["Authorization"].ToString();
+            var token = authorizationHeader.Substring("Bearer ".Length).Trim();
             var library = await _authInterface.VerifyAccessToken(token);
             if (library is null)
             {
@@ -86,7 +91,8 @@ namespace library_management_api.Controllers
         [HttpDelete("{Id}")]
         public async Task<ActionResult<ResponseModel<ReaderModel>>> DeleteReader(Guid Id)
         {
-            var token = HttpContext.Request.Cookies["AuthCookie"];
+            var authorizationHeader = Request.Headers["Authorization"].ToString();
+            var token = authorizationHeader.Substring("Bearer ".Length).Trim();
             var library = await _authInterface.VerifyAccessToken(token);
             if (library is null)
             {

--- a/library-management-api/Extensions/AuthenticationExtensions.cs
+++ b/library-management-api/Extensions/AuthenticationExtensions.cs
@@ -31,23 +31,22 @@ public static class AuthenticationExtensions
             {
                 OnMessageReceived = context =>
                 {
-                    context.Token = context.Request.Cookies["AuthCookie"];
+                    if (context.Request.Headers.ContainsKey("Authorization"))
+                    {
+                        var authHeader = context.Request.Headers["Authorization"].ToString();
+                        if (authHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+                        {
+                            context.Token = authHeader.Substring("Bearer ".Length).Trim();
+                        }
+                    }
                     return Task.CompletedTask;
                 },
                 OnAuthenticationFailed = context =>
                 {
-                Console.WriteLine($"Falha na autenticação: {context.Exception.Message}");
-                return Task.CompletedTask;
+                    Console.WriteLine($"Falha na autenticação: {context.Exception.Message}");
+                    return Task.CompletedTask;
                 }
             };
-        })
-        .AddCookie(CookieAuthenticationDefaults.AuthenticationScheme, options =>
-        {
-            options.Cookie.Name = "AuthCookie";
-            options.Cookie.HttpOnly = true;
-            options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
-            options.Cookie.SameSite = SameSiteMode.Strict;
-            options.ExpireTimeSpan = TimeSpan.FromDays(7);
         });
 
         return services;

--- a/library-management-api/Models/Dto/AuthResponseDto.cs
+++ b/library-management-api/Models/Dto/AuthResponseDto.cs
@@ -2,6 +2,7 @@ namespace library_management_api.Models;
 
 public class AuthResponseDto
 {
-    public string Name { get; set; }
     public string Id { get; set; }
+    public string Name { get; set; }
+    public string Token { get; set; }
 }

--- a/library-management-api/Services/Auth/AuthService.cs
+++ b/library-management-api/Services/Auth/AuthService.cs
@@ -43,11 +43,14 @@ public class AuthService : IAuthInterface
 
         _context.Add(newLibrary);
         await _context.SaveChangesAsync();
-        
+
+        var token = GetAccessToken(newLibrary.Id.ToString(), newLibrary.Name);
+
         var data = new AuthResponseDto()
         {
             Name = newLibrary.Name,
             Id = newLibrary.Id.ToString(),
+            Token = token,
         };
         
         response.Message = "Livraria registrada com sucesso!";
@@ -69,11 +72,12 @@ public class AuthService : IAuthInterface
             throw new UnauthorizedException("Acesso negado!");
         }
         
-
+        var token = GetAccessToken(validUser.Id.ToString(), validUser.Name);
         var data = new AuthResponseDto()
         {
             Name = validUser.Name,
             Id = validUser.Id.ToString(),
+            Token = token,
         };
         
         response.Message = "Login realizado com sucesso!";


### PR DESCRIPTION
Esta PR altera o método de autenticação da aplicação, substituindo o uso de cookies por autenticação via token JWT enviado no header `Authorization`.

---

## ✅ Alterações realizadas

- Remoção da autenticação baseada em cookies
- Implementação da autenticação via JWT nos headers das requisições
- Atualização dos endpoints para funcionar com o novo método
- Ajuste nas configurações de autenticação (`Extensions/AuthenticationExtension.cs`)

---

## 📚 Motivo da mudança

A autenticação via token JWT no header é mais adequada para a aplicação que esta sendo desenvolvida, garantindo maior compatibilidade com as tecnologias que serão usadas no front-end.

---

## 🧪 Testes

todos os endpoints foram testados com o novo método de autenticação e estão funcionando corretamente.  
O token JWT deve ser enviado no seguinte formato:

```http
Authorization: Bearer <seu-token-jwt>